### PR TITLE
Fix watcher stability and safety issues

### DIFF
--- a/cmd/watcher/main.go
+++ b/cmd/watcher/main.go
@@ -7,12 +7,20 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"runtime"
 	"strings"
+	"syscall"
 	"time"
-	"unicode"
 
 	"github.com/by275/watcher"
 )
+
+func commandFromString(command string) (string, []string) {
+	if runtime.GOOS == "windows" {
+		return "cmd", []string{"/C", command}
+	}
+	return "sh", []string{"-c", command}
+}
 
 func main() {
 	interval := flag.String("interval", "100ms", "watcher poll interval")
@@ -43,11 +51,7 @@ func main() {
 	var cmdName string
 	var cmdArgs []string
 	if *cmd != "" {
-		split := strings.FieldsFunc(*cmd, unicode.IsSpace)
-		cmdName = split[0]
-		if len(split) > 1 {
-			cmdArgs = split[1:]
-		}
+		cmdName, cmdArgs = commandFromString(*cmd)
 	}
 
 	// Create a new Watcher with the specified options.
@@ -142,8 +146,9 @@ func main() {
 
 	closed := make(chan struct{})
 
-	c := make(chan os.Signal)
-	signal.Notify(c, os.Kill, os.Interrupt)
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
+	defer signal.Stop(c)
 	go func() {
 		<-c
 		w.Close()

--- a/samefile_windows.go
+++ b/samefile_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package watcher
@@ -5,8 +6,5 @@ package watcher
 import "os"
 
 func sameFile(fi1, fi2 os.FileInfo) bool {
-	return fi1.ModTime() == fi2.ModTime() &&
-		fi1.Size() == fi2.Size() &&
-		fi1.Mode() == fi2.Mode() &&
-		fi1.IsDir() == fi2.IsDir()
+	return os.SameFile(fi1, fi2)
 }

--- a/watcher.go
+++ b/watcher.go
@@ -421,11 +421,25 @@ func (w *Watcher) RemoveRecursive(name string) (err error) {
 	// If it's a directory, delete all of it's contents recursively
 	// from w.files.
 	for path := range w.files {
-		if strings.HasPrefix(path, name) {
+		if isSubpath(path, name) {
 			delete(w.files, path)
 		}
 	}
 	return nil
+}
+
+func isSubpath(path, root string) bool {
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return false
+	}
+	if rel == "." {
+		return true
+	}
+	if rel == ".." {
+		return false
+	}
+	return !strings.HasPrefix(rel, ".."+string(filepath.Separator))
 }
 
 // Ignore adds paths that should be ignored.

--- a/watcher.go
+++ b/watcher.go
@@ -150,6 +150,15 @@ func New() *Watcher {
 	}
 }
 
+func isClosed(ch <-chan struct{}) bool {
+	select {
+	case <-ch:
+		return true
+	default:
+		return false
+	}
+}
+
 // SetMaxEvents controls the maximum amount of events that are sent on
 // the Event channel per watching cycle. If max events is less than 1, there is
 // no limit, which is the default.
@@ -561,6 +570,9 @@ func (w *Watcher) Start(d time.Duration) error {
 		w.mu.Unlock()
 		return ErrWatcherRunning
 	}
+	if isClosed(w.Closed) {
+		w.Closed = make(chan struct{})
+	}
 	w.running = true
 	w.mu.Unlock()
 
@@ -726,6 +738,9 @@ func (w *Watcher) Close() {
 	w.running = false
 	w.files = make(map[string]os.FileInfo)
 	w.names = make(map[string]bool)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	w.wg = &wg
 	w.mu.Unlock()
 	// Send a close signal to the Start method.
 	w.close <- struct{}{}

--- a/watcher.go
+++ b/watcher.go
@@ -613,14 +613,19 @@ func (w *Watcher) Start(d time.Duration) error {
 				close(w.Closed)
 				return nil
 			case event := <-evt:
-				if len(w.ops) > 0 { // Filter Ops.
-					_, found := w.ops[event.Op]
+				w.mu.Lock()
+				ops := w.ops
+				maxEvents := w.maxEvents
+				w.mu.Unlock()
+
+				if len(ops) > 0 { // Filter Ops.
+					_, found := ops[event.Op]
 					if !found {
 						continue
 					}
 				}
 				numEvents++
-				if w.maxEvents > 0 && numEvents > w.maxEvents {
+				if maxEvents > 0 && numEvents > maxEvents {
 					close(cancel)
 					break inner
 				}

--- a/watcher.go
+++ b/watcher.go
@@ -582,7 +582,9 @@ func (w *Watcher) Start(d time.Duration) error {
 	for {
 		// done lets the inner polling cycle loop know when the
 		// current cycle's method has finished executing.
-		done := make(chan struct{})
+		// Use a buffered channel so the polling goroutine can exit
+		// even when the inner loop stops early.
+		done := make(chan struct{}, 1)
 
 		// Any events that are found are first piped to evt before
 		// being sent to the main Event channel.

--- a/watcher_test.go
+++ b/watcher_test.go
@@ -481,6 +481,78 @@ func TestWatcherRemoveRecursive(t *testing.T) {
 	}
 }
 
+func TestWatcherRemoveRecursiveShouldNotRemovePrefixedSibling(t *testing.T) {
+	baseDir, err := ioutil.TempDir(".", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(baseDir)
+
+	targetDir := filepath.Join(baseDir, "dir")
+	siblingDir := filepath.Join(baseDir, "dir2")
+	if err := os.Mkdir(targetDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(siblingDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	targetFile := filepath.Join(targetDir, "target.txt")
+	siblingFile := filepath.Join(siblingDir, "sibling.txt")
+	if err := ioutil.WriteFile(targetFile, []byte{}, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := ioutil.WriteFile(siblingFile, []byte{}, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	w := New()
+	if err := w.AddRecursive(targetDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.AddRecursive(siblingDir); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := w.RemoveRecursive(targetDir); err != nil {
+		t.Fatal(err)
+	}
+
+	targetDirAbs, err := filepath.Abs(targetDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	targetFileAbs, err := filepath.Abs(targetFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	siblingDirAbs, err := filepath.Abs(siblingDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	siblingFileAbs, err := filepath.Abs(siblingFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, found := w.files[targetDirAbs]; found {
+		t.Fatalf("expected %s to be removed", targetDirAbs)
+	}
+	if _, found := w.files[targetFileAbs]; found {
+		t.Fatalf("expected %s to be removed", targetFileAbs)
+	}
+
+	if _, found := w.files[siblingDirAbs]; !found {
+		t.Fatalf("expected %s to remain", siblingDirAbs)
+	}
+	if _, found := w.files[siblingFileAbs]; !found {
+		t.Fatalf("expected %s to remain", siblingFileAbs)
+	}
+	if _, found := w.names[siblingDirAbs]; !found {
+		t.Fatalf("expected %s to remain in watched roots", siblingDirAbs)
+	}
+}
+
 func TestListFiles(t *testing.T) {
 	testDir, teardown := setup(t)
 	defer teardown()

--- a/watcher_test.go
+++ b/watcher_test.go
@@ -1150,6 +1150,64 @@ func TestSetMaxEvents(t *testing.T) {
 	}
 }
 
+func TestWatcherCloseWithMaxEvents(t *testing.T) {
+	testDir, teardown := setup(t)
+	defer teardown()
+
+	w := New()
+	w.SetMaxEvents(1)
+
+	if err := w.AddRecursive(testDir); err != nil {
+		t.Fatal(err)
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- w.Start(time.Millisecond * 10)
+	}()
+	w.Wait()
+	go func() {
+		for {
+			select {
+			case <-w.Event:
+			case <-w.Error:
+			case <-w.Closed:
+				return
+			}
+		}
+	}()
+
+	for i := 0; i < 20; i++ {
+		filePath := filepath.Join(testDir, fmt.Sprintf("storm_%d.txt", i))
+		if err := ioutil.WriteFile(filePath, []byte{}, 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	time.Sleep(time.Millisecond * 50)
+
+	closed := make(chan struct{})
+	go func() {
+		w.Close()
+		close(closed)
+	}()
+
+	select {
+	case <-closed:
+	case <-time.After(time.Second):
+		t.Fatal("watcher close blocked while max events were enabled")
+	}
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("expected Start to return nil, got %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for Start to return")
+	}
+}
+
 func TestOpsString(t *testing.T) {
 	testCases := []struct {
 		want     Op

--- a/watcher_test.go
+++ b/watcher_test.go
@@ -974,6 +974,32 @@ func TestWatcherStartWhenAlreadyRunning(t *testing.T) {
 	}
 }
 
+func TestWatcherRestartAfterClose(t *testing.T) {
+	w := New()
+
+	run := func() {
+		errCh := make(chan error, 1)
+		go func() {
+			errCh <- w.Start(time.Millisecond * 10)
+		}()
+
+		w.Wait()
+		w.Close()
+
+		select {
+		case err := <-errCh:
+			if err != nil {
+				t.Fatalf("expected start to return nil, got %v", err)
+			}
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for watcher to stop")
+		}
+	}
+
+	run()
+	run()
+}
+
 func BenchmarkEventRenameFile(b *testing.B) {
 	testDir, teardown := setup(b)
 	defer teardown()

--- a/watcher_test.go
+++ b/watcher_test.go
@@ -1166,14 +1166,9 @@ func TestWatcherCloseWithMaxEvents(t *testing.T) {
 		errCh <- w.Start(time.Millisecond * 10)
 	}()
 	w.Wait()
+	// Keep Event channel drained so Start loop can continue to the close select.
 	go func() {
-		for {
-			select {
-			case <-w.Event:
-			case <-w.Error:
-			case <-w.Closed:
-				return
-			}
+		for range w.Event {
 		}
 	}()
 
@@ -1184,8 +1179,6 @@ func TestWatcherCloseWithMaxEvents(t *testing.T) {
 		}
 	}
 
-	time.Sleep(time.Millisecond * 50)
-
 	closed := make(chan struct{})
 	go func() {
 		w.Close()
@@ -1194,7 +1187,7 @@ func TestWatcherCloseWithMaxEvents(t *testing.T) {
 
 	select {
 	case <-closed:
-	case <-time.After(time.Second):
+	case <-time.After(2 * time.Second):
 		t.Fatal("watcher close blocked while max events were enabled")
 	}
 
@@ -1203,7 +1196,7 @@ func TestWatcherCloseWithMaxEvents(t *testing.T) {
 		if err != nil {
 			t.Fatalf("expected Start to return nil, got %v", err)
 		}
-	case <-time.After(time.Second):
+	case <-time.After(2 * time.Second):
 		t.Fatal("timed out waiting for Start to return")
 	}
 }


### PR DESCRIPTION
## Summary
- fix restart safety after close (WaitGroup/channel lifecycle)
- prevent goroutine leak when maxEvents short-circuits a polling cycle
- guard Start reads of ops and maxEvents to avoid races
- prevent RemoveRecursive path-prefix overmatch (for example dir vs dir2)
- use os.SameFile on Windows for better move/rename detection
- improve CLI signal handling (SIGINT/SIGTERM) and command parsing via shell execution

## Verification
- GO111MODULE=off go test -count=1 -run 'TestWatcherRemoveRecursive$|TestWatcherRemoveRecursiveShouldNotRemovePrefixedSibling|TestWatcherRestartAfterClose|TestWatcherCloseWithMaxEvents'
- GO111MODULE=off go test -count=1 -run 'TestWatcherRemoveRecursiveShouldNotRemovePrefixedSibling|TestWatcherRestartAfterClose|TestWatcherCloseWithMaxEvents'
- GOOS=windows GO111MODULE=off go test -c
