### PR TITLE
Perf: optimize watcher polling and event paths

### DIFF
--- a/watcher.go
+++ b/watcher.go
@@ -506,6 +506,22 @@ func (fs *fileInfo) Sys() interface{} {
 	return fs.sys
 }
 
+type fileSignature struct {
+	modTime int64
+	size    int64
+	mode    os.FileMode
+	isDir   bool
+}
+
+func signatureFromFileInfo(info os.FileInfo) fileSignature {
+	return fileSignature{
+		modTime: info.ModTime().UnixNano(),
+		size:    info.Size(),
+		mode:    info.Mode(),
+		isDir:   info.IsDir(),
+	}
+}
+
 // TriggerEvent is a method that can be used to trigger an event, separate to
 // the file watching process.
 func (w *Watcher) TriggerEvent(eventType Op, file os.FileInfo) {
@@ -704,8 +720,23 @@ func (w *Watcher) pollEvents(files map[string]os.FileInfo, evt chan Event,
 	}
 
 	// Check for renames and moves.
+	createBuckets := make(map[fileSignature][]string, len(creates))
+	for path, info := range creates {
+		sig := signatureFromFileInfo(info)
+		createBuckets[sig] = append(createBuckets[sig], path)
+	}
+
 	for path1, info1 := range removes {
-		for path2, info2 := range creates {
+		sig := signatureFromFileInfo(info1)
+		candidates := createBuckets[sig]
+
+		for i := 0; i < len(candidates); i++ {
+			path2 := candidates[i]
+			info2, found := creates[path2]
+			if !found {
+				continue
+			}
+
 			if sameFile(info1, info2) {
 				e := Event{
 					Op:       Move,
@@ -721,12 +752,20 @@ func (w *Watcher) pollEvents(files map[string]os.FileInfo, evt chan Event,
 
 				delete(removes, path1)
 				delete(creates, path2)
+				candidates[i] = candidates[len(candidates)-1]
+				candidates = candidates[:len(candidates)-1]
+				if len(candidates) == 0 {
+					delete(createBuckets, sig)
+				} else {
+					createBuckets[sig] = candidates
+				}
 
 				select {
 				case <-cancel:
 					return
 				case evt <- e:
 				}
+				break
 			}
 		}
 	}

--- a/watcher.go
+++ b/watcher.go
@@ -272,23 +272,26 @@ func (w *Watcher) list(name string) (map[string]os.FileInfo, error) {
 }
 
 func listWithConfig(name string, cfg scanConfig) (map[string]os.FileInfo, error) {
-	fileList := make(map[string]os.FileInfo)
-
 	// Make sure name exists.
 	stat, err := os.Stat(name)
 	if err != nil {
 		return nil, err
 	}
 
+	fileList := make(map[string]os.FileInfo)
 	fileList[name] = stat
-	for _, f := range cfg.ffh {
-		err := f(stat, name)
-		if err == ErrSkip {
-			delete(fileList, name)
-			continue
-		}
-		if err != nil {
-			return nil, err
+	includeRoot := true
+	if len(cfg.ffh) > 0 {
+		for _, f := range cfg.ffh {
+			err := f(stat, name)
+			if err == ErrSkip {
+				delete(fileList, name)
+				includeRoot = false
+				continue
+			}
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 
@@ -301,6 +304,10 @@ func listWithConfig(name string, cfg scanConfig) (map[string]os.FileInfo, error)
 	fInfoList, err := ioutil.ReadDir(name)
 	if err != nil {
 		return nil, err
+	}
+	fileList = make(map[string]os.FileInfo, len(fInfoList)+1)
+	if includeRoot {
+		fileList[name] = stat
 	}
 	// Add all of the files in the directory to the file list as long
 	// as they aren't on the ignored list or are hidden files if ignoreHidden
@@ -317,13 +324,15 @@ outer:
 			continue
 		}
 
-		for _, f := range cfg.ffh {
-			err := f(fInfo, path)
-			if err == ErrSkip {
-				continue outer
-			}
-			if err != nil {
-				return nil, err
+		if len(cfg.ffh) > 0 {
+			for _, f := range cfg.ffh {
+				err := f(fInfo, path)
+				if err == ErrSkip {
+					continue outer
+				}
+				if err != nil {
+					return nil, err
+				}
 			}
 		}
 
@@ -389,13 +398,15 @@ func listRecursiveWithConfig(name string, cfg scanConfig) (map[string]os.FileInf
 			return nil
 		}
 
-		for _, f := range cfg.ffh {
-			err := f(info, path)
-			if err == ErrSkip {
-				return nil
-			}
-			if err != nil {
-				return err
+		if len(cfg.ffh) > 0 {
+			for _, f := range cfg.ffh {
+				err := f(info, path)
+				if err == ErrSkip {
+					return nil
+				}
+				if err != nil {
+					return err
+				}
 			}
 		}
 

--- a/watcher.go
+++ b/watcher.go
@@ -138,8 +138,9 @@ func New() *Watcher {
 	wg.Add(1)
 
 	return &Watcher{
-		Event:   make(chan Event),
-		Error:   make(chan error),
+		// Buffering reduces producer stalls when consumers are slower than scan cycles.
+		Event:   make(chan Event, 64),
+		Error:   make(chan error, 16),
 		Closed:  make(chan struct{}),
 		close:   make(chan struct{}),
 		mu:      new(sync.Mutex),
@@ -659,7 +660,13 @@ func (w *Watcher) Start(d time.Duration) error {
 					close(cancel)
 					break inner
 				}
-				w.Event <- event
+				select {
+				case <-w.close:
+					close(cancel)
+					close(w.Closed)
+					return nil
+				case w.Event <- event:
+				}
 			case <-done: // Current cycle is finished.
 				break inner
 			}

--- a/watcher.go
+++ b/watcher.go
@@ -195,45 +195,80 @@ func (w *Watcher) FilterOps(ops ...Op) {
 	w.mu.Unlock()
 }
 
+type scanConfig struct {
+	ffh          []FilterFileHookFunc
+	ignored      map[string]struct{}
+	ignoreHidden bool
+}
+
+func (w *Watcher) snapshotScanConfigLocked() scanConfig {
+	cfg := scanConfig{
+		ffh:          append([]FilterFileHookFunc(nil), w.ffh...),
+		ignored:      make(map[string]struct{}, len(w.ignored)),
+		ignoreHidden: w.ignoreHidden,
+	}
+	for path := range w.ignored {
+		cfg.ignored[path] = struct{}{}
+	}
+	return cfg
+}
+
+func rootIgnoredOrHidden(name string, cfg scanConfig) (bool, error) {
+	if _, ignored := cfg.ignored[name]; ignored {
+		return true, nil
+	}
+
+	isHidden, err := isHiddenFile(name)
+	if err != nil {
+		return false, err
+	}
+	return cfg.ignoreHidden && isHidden, nil
+}
+
 // Add adds either a single file or directory to the file list.
 func (w *Watcher) Add(name string) (err error) {
 	w.mu.Lock()
-	defer w.mu.Unlock()
-
+	cfg := w.snapshotScanConfigLocked()
+	w.mu.Unlock()
 	name, err = filepath.Abs(name)
 	if err != nil {
 		return err
 	}
 
-	// If name is on the ignored list or if hidden files are
-	// ignored and name is a hidden file or directory, simply return.
-	_, ignored := w.ignored[name]
-
-	isHidden, err := isHiddenFile(name)
+	skipRoot, err := rootIgnoredOrHidden(name, cfg)
 	if err != nil {
 		return err
 	}
-
-	if ignored || (w.ignoreHidden && isHidden) {
+	if skipRoot {
 		return nil
 	}
 
 	// Add the directory's contents to the files list.
-	fileList, err := w.list(name)
+	fileList, err := listWithConfig(name, cfg)
 	if err != nil {
 		return err
 	}
+
+	w.mu.Lock()
 	for k, v := range fileList {
 		w.files[k] = v
 	}
 
 	// Add the name to the names list.
 	w.names[name] = false
+	w.mu.Unlock()
 
 	return nil
 }
 
 func (w *Watcher) list(name string) (map[string]os.FileInfo, error) {
+	w.mu.Lock()
+	cfg := w.snapshotScanConfigLocked()
+	w.mu.Unlock()
+	return listWithConfig(name, cfg)
+}
+
+func listWithConfig(name string, cfg scanConfig) (map[string]os.FileInfo, error) {
 	fileList := make(map[string]os.FileInfo)
 
 	// Make sure name exists.
@@ -243,7 +278,7 @@ func (w *Watcher) list(name string) (map[string]os.FileInfo, error) {
 	}
 
 	fileList[name] = stat
-	for _, f := range w.ffh {
+	for _, f := range cfg.ffh {
 		err := f(stat, name)
 		if err == ErrSkip {
 			delete(fileList, name)
@@ -270,18 +305,16 @@ func (w *Watcher) list(name string) (map[string]os.FileInfo, error) {
 outer:
 	for _, fInfo := range fInfoList {
 		path := filepath.Join(name, fInfo.Name())
-		_, ignored := w.ignored[path]
-
-		isHidden, err := isHiddenFile(path)
+		skipPath, err := rootIgnoredOrHidden(path, cfg)
 		if err != nil {
 			return nil, err
 		}
 
-		if ignored || (w.ignoreHidden && isHidden) {
+		if skipPath {
 			continue
 		}
 
-		for _, f := range w.ffh {
+		for _, f := range cfg.ffh {
 			err := f(fInfo, path)
 			if err == ErrSkip {
 				continue outer
@@ -299,28 +332,39 @@ outer:
 // AddRecursive adds either a single file or directory recursively to the file list.
 func (w *Watcher) AddRecursive(name string) (err error) {
 	w.mu.Lock()
-	defer w.mu.Unlock()
+	cfg := w.snapshotScanConfigLocked()
+	w.mu.Unlock()
 
 	name, err = filepath.Abs(name)
 	if err != nil {
 		return err
 	}
 
-	fileList, err := w.listRecursive(name)
+	fileList, err := listRecursiveWithConfig(name, cfg)
 	if err != nil {
 		return err
 	}
+
+	w.mu.Lock()
 	for k, v := range fileList {
 		w.files[k] = v
 	}
 
 	// Add the name to the names list.
 	w.names[name] = true
+	w.mu.Unlock()
 
 	return nil
 }
 
 func (w *Watcher) listRecursive(name string) (map[string]os.FileInfo, error) {
+	w.mu.Lock()
+	cfg := w.snapshotScanConfigLocked()
+	w.mu.Unlock()
+	return listRecursiveWithConfig(name, cfg)
+}
+
+func listRecursiveWithConfig(name string, cfg scanConfig) (map[string]os.FileInfo, error) {
 	fileList := make(map[string]os.FileInfo)
 
 	return fileList, filepath.Walk(name, func(path string, info os.FileInfo, err error) error {
@@ -330,21 +374,19 @@ func (w *Watcher) listRecursive(name string) (map[string]os.FileInfo, error) {
 
 		// If path is ignored and it's a directory, skip the directory. If it's
 		// ignored and it's a single file, skip the file.
-		_, ignored := w.ignored[path]
-
-		isHidden, err := isHiddenFile(path)
+		skipPath, err := rootIgnoredOrHidden(path, cfg)
 		if err != nil {
 			return err
 		}
 
-		if ignored || (w.ignoreHidden && isHidden) {
+		if skipPath {
 			if info.IsDir() {
 				return filepath.SkipDir
 			}
 			return nil
 		}
 
-		for _, f := range w.ffh {
+		for _, f := range cfg.ffh {
 			err := f(info, path)
 			if err == ErrSkip {
 				return nil
@@ -535,47 +577,47 @@ func (w *Watcher) TriggerEvent(eventType Op, file os.FileInfo) {
 
 func (w *Watcher) retrieveFileList() map[string]os.FileInfo {
 	w.mu.Lock()
-	defer w.mu.Unlock()
+	cfg := w.snapshotScanConfigLocked()
+	names := make(map[string]bool, len(w.names))
+	for name, recursive := range w.names {
+		names[name] = recursive
+	}
+	w.mu.Unlock()
 
 	fileList := make(map[string]os.FileInfo)
 
-	var list map[string]os.FileInfo
-	var err error
-
-	for name, recursive := range w.names {
+	for name, recursive := range names {
+		var (
+			list map[string]os.FileInfo
+			err  error
+		)
 		if recursive {
-			list, err = w.listRecursive(name)
+			list, err = listRecursiveWithConfig(name, cfg)
 			if err != nil {
 				if os.IsNotExist(err) {
-					w.mu.Unlock()
 					pathErr, ok := err.(*os.PathError)
-					if ok {
-						if name == pathErr.Path {
-							w.Error <- ErrWatchedFileDeleted
-							w.RemoveRecursive(name)
-						}
+					if ok && name == pathErr.Path {
+						w.Error <- ErrWatchedFileDeleted
+						_ = w.RemoveRecursive(name)
 					}
-					w.mu.Lock()
 				} else {
 					w.Error <- err
 				}
+				continue
 			}
 		} else {
-			list, err = w.list(name)
+			list, err = listWithConfig(name, cfg)
 			if err != nil {
 				if os.IsNotExist(err) {
-					w.mu.Unlock()
 					pathErr, ok := err.(*os.PathError)
-					if ok {
-						if name == pathErr.Path {
-							w.Error <- ErrWatchedFileDeleted
-							w.Remove(name)
-						}
+					if ok && name == pathErr.Path {
+						w.Error <- ErrWatchedFileDeleted
+						_ = w.Remove(name)
 					}
-					w.mu.Lock()
 				} else {
 					w.Error <- err
 				}
+				continue
 			}
 		}
 		// Add the file's to the file list.

--- a/watcher.go
+++ b/watcher.go
@@ -617,9 +617,10 @@ func (w *Watcher) retrieveFileList() map[string]os.FileInfo {
 	for name, recursive := range w.names {
 		names[name] = recursive
 	}
+	prevFileCount := len(w.files)
 	w.mu.Unlock()
 
-	fileList := make(map[string]os.FileInfo)
+	fileList := make(map[string]os.FileInfo, prevFileCount)
 
 	for name, recursive := range names {
 		var (
@@ -765,8 +766,8 @@ func (w *Watcher) pollEvents(files map[string]os.FileInfo, evt chan Event,
 	w.mu.Unlock()
 
 	// Store create and remove events for use to check for rename events.
-	creates := make(map[string]os.FileInfo)
-	removes := make(map[string]os.FileInfo)
+	creates := make(map[string]os.FileInfo, len(files))
+	removes := make(map[string]os.FileInfo, len(oldFiles))
 
 	// Check for removed files.
 	for path, info := range oldFiles {

--- a/watcher.go
+++ b/watcher.go
@@ -201,6 +201,11 @@ type scanConfig struct {
 	ignoreHidden bool
 }
 
+type eventConfig struct {
+	ops       map[Op]struct{}
+	maxEvents int
+}
+
 func (w *Watcher) snapshotScanConfigLocked() scanConfig {
 	cfg := scanConfig{
 		ffh:          append([]FilterFileHookFunc(nil), w.ffh...),
@@ -226,6 +231,22 @@ func rootIgnoredOrHidden(name string, cfg scanConfig) (bool, error) {
 		return false, err
 	}
 	return isHidden, nil
+}
+
+func (w *Watcher) snapshotEventConfig() eventConfig {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	cfg := eventConfig{
+		maxEvents: w.maxEvents,
+	}
+	if len(w.ops) > 0 {
+		cfg.ops = make(map[Op]struct{}, len(w.ops))
+		for op := range w.ops {
+			cfg.ops[op] = struct{}{}
+		}
+	}
+	return cfg
 }
 
 // Add adds either a single file or directory to the file list.
@@ -679,6 +700,7 @@ func (w *Watcher) Start(d time.Duration) error {
 
 		// Retrieve the file list for all watched file's and dirs.
 		fileList := w.retrieveFileList()
+		cfg := w.snapshotEventConfig()
 
 		// cancel can be used to cancel the current event polling function.
 		cancel := make(chan struct{})
@@ -700,19 +722,14 @@ func (w *Watcher) Start(d time.Duration) error {
 				close(w.Closed)
 				return nil
 			case event := <-evt:
-				w.mu.Lock()
-				ops := w.ops
-				maxEvents := w.maxEvents
-				w.mu.Unlock()
-
-				if len(ops) > 0 { // Filter Ops.
-					_, found := ops[event.Op]
+				if len(cfg.ops) > 0 { // Filter Ops.
+					_, found := cfg.ops[event.Op]
 					if !found {
 						continue
 					}
 				}
 				numEvents++
-				if maxEvents > 0 && numEvents > maxEvents {
+				if cfg.maxEvents > 0 && numEvents > cfg.maxEvents {
 					close(cancel)
 					break inner
 				}

--- a/watcher.go
+++ b/watcher.go
@@ -662,14 +662,18 @@ func (w *Watcher) Start(d time.Duration) error {
 func (w *Watcher) pollEvents(files map[string]os.FileInfo, evt chan Event,
 	cancel chan struct{}) {
 	w.mu.Lock()
-	defer w.mu.Unlock()
+	oldFiles := make(map[string]os.FileInfo, len(w.files))
+	for path, info := range w.files {
+		oldFiles[path] = info
+	}
+	w.mu.Unlock()
 
 	// Store create and remove events for use to check for rename events.
 	creates := make(map[string]os.FileInfo)
 	removes := make(map[string]os.FileInfo)
 
 	// Check for removed files.
-	for path, info := range w.files {
+	for path, info := range oldFiles {
 		if _, found := files[path]; !found {
 			removes[path] = info
 		}
@@ -677,7 +681,7 @@ func (w *Watcher) pollEvents(files map[string]os.FileInfo, evt chan Event,
 
 	// Check for created files, writes and chmods.
 	for path, info := range files {
-		oldInfo, found := w.files[path]
+		oldInfo, found := oldFiles[path]
 		if !found {
 			// A file was created.
 			creates[path] = info

--- a/watcher.go
+++ b/watcher.go
@@ -217,12 +217,15 @@ func rootIgnoredOrHidden(name string, cfg scanConfig) (bool, error) {
 	if _, ignored := cfg.ignored[name]; ignored {
 		return true, nil
 	}
+	if !cfg.ignoreHidden {
+		return false, nil
+	}
 
 	isHidden, err := isHiddenFile(name)
 	if err != nil {
 		return false, err
 	}
-	return cfg.ignoreHidden && isHidden, nil
+	return isHidden, nil
 }
 
 // Add adds either a single file or directory to the file list.

--- a/watcher_test.go
+++ b/watcher_test.go
@@ -1273,6 +1273,51 @@ func TestWatcherCloseWithMaxEvents(t *testing.T) {
 	}
 }
 
+func TestWatcherCloseWithoutEventConsumer(t *testing.T) {
+	testDir, teardown := setup(t)
+	defer teardown()
+
+	w := New()
+
+	if err := w.AddRecursive(testDir); err != nil {
+		t.Fatal(err)
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- w.Start(time.Millisecond * 10)
+	}()
+	w.Wait()
+
+	for i := 0; i < 128; i++ {
+		filePath := filepath.Join(testDir, fmt.Sprintf("burst_%d.txt", i))
+		if err := ioutil.WriteFile(filePath, []byte{}, 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	closed := make(chan struct{})
+	go func() {
+		w.Close()
+		close(closed)
+	}()
+
+	select {
+	case <-closed:
+	case <-time.After(2 * time.Second):
+		t.Fatal("watcher close blocked without an event consumer")
+	}
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("expected Start to return nil, got %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for Start to return")
+	}
+}
+
 func TestOpsString(t *testing.T) {
 	testCases := []struct {
 		want     Op


### PR DESCRIPTION
## Summary
- reduce lock hold time in event polling and snapshot scan configs outside hot loops
- reduce rename detection candidate search with signature bucketing
- add buffered channels and close-path handling to avoid stalls during bursts
- preallocate maps and trim allocation overhead in scan/diff paths
- skip hidden-file checks when hidden filtering is disabled

## Notes
- focused on performance improvements while preserving current behavior
- added/updated tests around close behavior and regression-sensitive paths

## Verification
- GO111MODULE=off go test -count=1 -run 'TestSetMaxEvents|TestWatcherStartWhenAlreadyRunning|TestWatcherRestartAfterClose|TestWatcherCloseWithMaxEvents|TestWatcherCloseWithoutEventConsumer|TestEventRenameFile'
- GO111MODULE=off go test -count=1 -run 'TestListFiles|TestWatcherAdd$|TestWatcherAddRecursive|TestFilterFileShouldAlsoApplyOnRootFolder|TestWatcherRestartAfterClose|TestWatcherCloseWithoutEventConsumer'
- GO111MODULE=off go test -run '^$' -bench 'BenchmarkListFiles|BenchmarkEventRenameFile' -benchtime=5x
